### PR TITLE
Update AWS MCP docs for May 6, 2026 GA release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [May 2026] - 2026-05-09
+
+### Changed
+- **AWS MCP Server GA (May 6, 2026)** — Updated documentation to reflect general availability. The `aws-mcp:InvokeMcp`, `aws-mcp:CallReadOnlyTool`, and `aws-mcp:CallReadWriteTool` permissions are retired and have no effect; access is now controlled through standard IAM policies. The `aws:ViaAWSMCPService` (Boolean) and `aws:CalledViaAWSMCP` (service principal String) global condition context keys are added to every MCP-initiated request, intended for `Deny`-style scoping per the AWS-documented pattern.
+- **Skills replace Agent SOPs** — Agent SOPs are renamed to **Skills** and are now contributed and maintained by individual AWS service teams. Updated `servers/aws.md`, `tutorials/07-aws-mcp-remote-server.md`, and `servers/configs/registry.yaml`.
+- **Tutorials/Servers refresh** — `tutorials/07-aws-mcp-remote-server.md` and `servers/aws.md` updated to "May 2026" and rewritten around the GA model. The "Unified Architecture (Preview)" block in `servers/aws.md` is removed (superseded by GA).
+
+### Added
+- **`run_script` tool** documented in `tutorials/07-aws-mcp-remote-server.md` and `servers/aws.md` — server-side Python sandbox that lets the agent chain multiple AWS calls in a single round-trip.
+- **`retrieve_skill` tool** documented in `tutorials/07-aws-mcp-remote-server.md` and `servers/aws.md` — loads a specific Skill on demand. Both files also note the `aws___` prefix used by MCP clients when listing tools.
+- **Frankfurt (`eu-central-1`) endpoint** documented alongside `us-east-1`: `https://aws-mcp.eu-central-1.api.aws/mcp`.
+- **Observability narrative** — CloudWatch metrics under the `AWS-MCP` namespace and CloudTrail audit visibility, with the new context keys used to separate human and agent traffic.
+- **Pricing line** in `servers/aws.md`: no charge for the server itself; pay only for AWS resources used and data transfer.
+- **GA note** in `governance/remote-mcp-servers.md` (one sentence) noting the May 6, 2026 GA and the unauthenticated documentation tools.
+- **Credential-method note** in `tutorials/07-aws-mcp-remote-server.md` — points readers to AWS-recommended `aws login` (auto-rotates credentials every 15 minutes) and `aws configure sso` as alternatives to static IAM access keys, while keeping the IAM-user path for users without SSO.
+- **MCP Proxy for AWS explanation** in `tutorials/07-aws-mcp-remote-server.md` and `servers/aws.md` — clarifies what `uvx mcp-proxy-for-aws@latest` actually invokes (the local STDIO-to-HTTPS bridge that handles SigV4 signing) and links to the [aws/mcp-proxy-for-aws](https://github.com/aws/mcp-proxy-for-aws) repository.
+
+### Fixed
+- Stale references to `aws-mcp:InvokeMcp` removed from `tutorials/02-amazon-kiro-cli-cost-analysis.md`.
+- Stale "Agent SOPs" reference updated in `servers/configs/registry.yaml`.
+
+---
+
 ## [March 2026] - 2026-03-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ A practical resource hub for FinOps practitioners, cloud engineers, and platform
 
 ---
 
-## Recent Updates (March 2026)
+## Recent Updates (May 2026)
 
+- **AWS MCP Server GA** (May 6, 2026) — Now part of the broader Agent Toolkit for AWS. The previous `aws-mcp:InvokeMcp` permission is replaced by standard IAM policies using the `aws:ViaAWSMCPService` and `aws:CalledViaAWSMCP` context keys. New `run_script` tool runs short Python scripts in a server-side sandbox for multi-step workflows. Frankfurt (`eu-central-1`) endpoint added alongside `us-east-1`. Updated: [tutorial](./tutorials/07-aws-mcp-remote-server.md), [server doc](./servers/aws.md).
 - **New: Workflow & Collaboration Servers** — [FinOps Tagging Compliance](./servers/tagging.md), [JIRA](./servers/jira.md), and [Slack](./servers/slack.md) MCP servers for automated cost governance
 - **Registry Backfill** — [`registry.yaml`](./servers/configs/registry.yaml) now lists all 18 documented MCP servers
 - **MCP Authentication Vulnerabilities** (January 2026) — Critical security risks and remediation ([read more](./governance/mcp-authentication-vulnerabilities-2026.md))
-- **AWS MCP Remote Server** — GA with 15,000+ AWS APIs ([tutorial](./tutorials/07-aws-mcp-remote-server.md))
 
 ---
 

--- a/governance/remote-mcp-servers.md
+++ b/governance/remote-mcp-servers.md
@@ -4,7 +4,7 @@
 
 Remote MCP servers are cloud-hosted or network-accessible MCP servers that clients connect to over HTTP/HTTPS or Server-Sent Events (SSE), as opposed to local servers running on the same machine as the MCP client.
 
-Remote MCP support became mainstream in 2025, with Claude Code adding native support in June 2025 and other major clients following suit.
+Remote MCP support became mainstream in 2025, with Claude Code adding native support in June 2025 and other major clients following suit. The AWS MCP Server reached general availability on May 6, 2026, and its documentation tools (`search_documentation`, `read_documentation`) no longer require authentication — only `call_aws` and `run_script` use IAM credentials.
 
 ---
 

--- a/servers/aws.md
+++ b/servers/aws.md
@@ -1,107 +1,74 @@
 # AWS MCP Servers for Cloud Cost Optimization
 
-**Last Updated**: March 2026
+**Last Updated**: May 2026
 
-A comprehensive guide to AWS MCP servers for FinOps automation, cloud cost optimization, and AI-powered cost management. Covers the AWS Remote MCP Server (15,000+ APIs), Pricing API, Cost Explorer, CloudWatch, Billing & Cost Management, and community FinOps servers.
+A comprehensive guide to AWS MCP servers for FinOps automation, cloud cost optimization, and AI-powered cost management. Covers the AWS MCP Server (15,000+ APIs, GA on May 6, 2026), Pricing API, Cost Explorer, CloudWatch, Billing & Cost Management, and community FinOps servers.
 
 ← [Back to Servers](./INDEX.md) | [Home](../README.md) | [Azure Servers](./azure.md) | [GCP Servers](./gcp.md)
 
 ---
 
-## ⭐ AWS MCP Remote Server - Generally Available
+## ⭐ AWS MCP Server — Generally Available (May 6, 2026)
 
-**Official AWS Documentation**: [AWS MCP User Guide](https://docs.aws.amazon.com/aws-mcp/latest/userguide/what-is-mcp-server.html)
-**Repository**: [awslabs/mcp](https://github.com/awslabs/mcp)
+**Official AWS Documentation**: [Agent Toolkit for AWS — User Guide](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/mcp-server.html)
+**Announcement**: [The AWS MCP Server is now generally available](https://aws.amazon.com/blogs/aws/the-aws-mcp-server-is-now-generally-available/)
+**Local proxy** (used by MCP clients): [aws/mcp-proxy-for-aws](https://github.com/aws/mcp-proxy-for-aws) — a small open-source helper that bridges STDIO to the remote HTTPS endpoint and signs requests with SigV4 using your local AWS credentials. Distributed via `uvx mcp-proxy-for-aws@latest`; no manual install.
 **Status**: Generally Available (GA)
 
-### 🎯 Start Here for Complete AWS Interactions!
+### 🎯 Start Here for Complete AWS Interactions
 
-AWS's **first remote, managed MCP server** is now Generally Available. This hosted solution eliminates local installation complexity while providing comprehensive access to all AWS services, documentation, and best practices.
+The AWS MCP Server is the managed, remote MCP entry point for AWS — one endpoint, 15,000+ AWS APIs, no local server installation. As of GA, it ships inside the broader **Agent Toolkit for AWS**, which bundles the MCP Server, **Skills**, **Plugins**, and project-level **Rules files**.
 
-#### Why Choose the Remote Server?
+#### What changed at GA
 
-**Zero Installation Overhead**
-- No local dependencies or version management
-- AWS hosts and maintains the infrastructure
-- Always up-to-date with latest AWS APIs and documentation
-- Works with any MCP-compatible client
+For FinOps users, three changes matter most:
 
-**Comprehensive AWS Coverage**
-- **15,000+ AWS APIs** through one unified interface
-- Real-time access to AWS documentation, API references, What's New posts
-- Getting Started guides and best practices built-in
-- Complete resource management across all AWS services
+1. **Simpler IAM model.** The previous `aws-mcp:InvokeMcp`, `aws-mcp:CallReadOnlyTool`, and `aws-mcp:CallReadWriteTool` permissions are gone — they no longer have any effect, and AWS recommends removing them. Access is now expressed through standard IAM policies on the underlying AWS actions (`ce:GetCostAndUsage`, `pricing:GetProducts`, etc.). Two global condition context keys are automatically added to every MCP-initiated request: `aws:ViaAWSMCPService` (Boolean, `true` for any AWS managed MCP server) and `aws:CalledViaAWSMCP` (String, the specific MCP service principal — e.g. `aws-mcp.amazonaws.com`). The AWS-documented pattern is to use them in `Deny` statements when the same IAM identity is shared between human and agent use, so the agent stays narrower than the human.
+2. **`run_script` tool.** A short Python script runs server-side in an isolated sandbox, inherits the caller's IAM permissions, has no network egress outside AWS, and lets the agent chain multiple AWS calls in a single round-trip. For multi-step FinOps work — month-over-month growth analysis, commitment portfolio reviews, multi-account aggregation — this avoids the round-trip overhead of issuing one `call_aws` per API operation.
+3. **Documentation tools require no authentication.** `search_documentation` and `read_documentation` work without IAM credentials. Only `call_aws` and `run_script` need IAM.
 
-**Agent Standard Operating Procedures (SOPs)**
-- Pre-built workflows for common AWS tasks
-- Codified best practices for FinOps automation
-- Command validation and security controls
-- Accelerated time from idea to implementation
+`call_aws` itself also now supports file uploads and long-running operations, which makes it usable for tasks that previously needed bespoke tooling.
 
-**Enterprise-Grade Reliability**
-- Built on AWS's scalable infrastructure
-- IAM-based security and access control
-- Centralized audit logging and compliance
-- Production-ready for enterprise deployments
+#### Capabilities
+
+**One endpoint, 15,000+ AWS APIs**
+- `call_aws` — executes any AWS API operation with the caller's IAM credentials; supports file uploads and long-running operations
+- `run_script` — runs a short Python script in a server-side sandbox; no network access outside AWS; inherits IAM permissions; ideal for chaining multiple API calls
+- `search_documentation` and `read_documentation` — retrieve current AWS documentation; no authentication required
+- `retrieve_skill` — loads a specific Skill on demand so the agent only consumes context it actually needs
+
+When listed by an MCP client, these tools appear with an `aws___` prefix (e.g. `aws___call_aws`).
+
+**Skills** (replacing the previous Agent SOPs)
+- Curated packages of instructions, scripts, and reference material for specific AWS tasks
+- Loaded on demand so they do not consume unnecessary context
+- **Contributed and maintained by the individual AWS service teams** that own each domain — meaning the guidance reflects current best practice for each service rather than a generic template
+
+**Regional endpoints** (pick the one closest to your users)
+- `https://aws-mcp.us-east-1.api.aws/mcp` — US East / N. Virginia
+- `https://aws-mcp.eu-central-1.api.aws/mcp` — Europe / Frankfurt
+
+Both endpoints can call APIs in any AWS region.
+
+**Observability and audit**
+- CloudWatch metrics published under the `AWS-MCP` namespace — separate visibility on agent traffic
+- CloudTrail captures all API calls; combined with the `aws:ViaAWSMCPService` context key, you can cleanly distinguish human and agent activity in audit data
+
+**Pricing**
+- No charge for the AWS MCP Server itself. You pay only for the AWS resources used and any data transfer.
 
 #### 📚 Step-by-Step Tutorial
 
-**New to the AWS MCP Remote Server?** Follow our complete tutorial:
+**New to the AWS MCP Server?** Follow our tutorial:
 
-👉 **[Tutorial: AWS MCP Remote Server - Complete AWS Interactions](../tutorials/07-aws-mcp-remote-server.md)**
+👉 **[Tutorial: AWS MCP Remote Server — Complete AWS Interactions](../tutorials/07-aws-mcp-remote-server.md)**
 
 Learn how to:
-- Set up IAM permissions for secure access
-- Configure the remote server in Claude Desktop, VS Code, or Claude Code
+- Set up an IAM policy that uses the new context keys
+- Configure the server in Claude Desktop, VS Code, or Claude Code (us-east-1 or eu-central-1)
 - Query AWS APIs, documentation, and resources through natural language
-- Use Agent SOPs for FinOps workflows and cost optimization
-
----
-
-## 🚀 AWS MCP Server (Unified Architecture) - Preview
-
-**Repository**: [awslabs/mcp](https://github.com/awslabs/mcp)
-**Announcement**: November 2025
-**Status**: Preview (Generally Available Soon)
-
-AWS has introduced a **unified AWS MCP Server** that consolidates multiple AWS MCP capabilities into a single, powerful interface. This represents the future of AWS MCP integration, orchestrating access to AWS services through a streamlined architecture.
-
-### What's New in the Unified AWS MCP Server
-
-**🎯 Consolidated Architecture**
-- **Single server** combines AWS API MCP and AWS Knowledge servers
-- Access to **15,000+ AWS APIs** through one unified interface
-- Simplified configuration and deployment
-- Built-in orchestration across AWS services
-
-**📚 Agent Standard Operating Procedures (SOPs)**
-- Pre-built workflows for common AWS tasks
-- Best practices codified into reusable patterns
-- Accelerates FinOps automation and cost optimization
-- Reduces time from idea to implementation
-
-**☁️ Remote MCP Server Support**
-- AWS Knowledge MCP server is now **Generally Available** (GA)
-- AWS's **first remote MCP server** (vs local STDIO)
-- Cloud-hosted, scalable infrastructure
-- Enhanced security and enterprise controls
-
-### Key Benefits for FinOps
-
-1. **Unified Cost Management**: Access pricing, billing, and optimization APIs through one server
-2. **Simplified Setup**: Replace multiple server configurations with a single unified deployment
-3. **Enhanced Reliability**: AWS-managed infrastructure with enterprise SLAs
-4. **Better Performance**: Optimized for AWS API interactions and data retrieval
-5. **Task Workflows**: Leverage MCP Specification 2025-11-25 tasks for long-running cost analyses
-
-### Migration Path
-
-The unified AWS MCP Server is designed to work alongside existing individual servers:
-- **Current users**: Continue using individual servers (Pricing, Cost Explorer, CloudWatch, etc.)
-- **New users**: Consider starting with the unified AWS MCP Server for simplified setup
-- **Enterprise teams**: Evaluate remote MCP deployment for centralized management
-
-👉 **Learn more**: [AWS MCP Server Documentation](https://awslabs.github.io/mcp/)
+- Use `run_script` for multi-step FinOps workflows
+- Use Skills for cost optimization and other AWS tasks
 
 ---
 

--- a/servers/configs/registry.yaml
+++ b/servers/configs/registry.yaml
@@ -85,17 +85,18 @@
     - aws
     - community
 
-- name: aws-mcp-remote-server
+- name: aws-mcp-server
   provider: AWS
-  repo: https://github.com/awslabs/mcp
-  homepage: https://docs.aws.amazon.com/aws-mcp/latest/userguide/what-is-mcp-server.html
+  repo: https://github.com/aws/mcp-proxy-for-aws
+  homepage: https://docs.aws.amazon.com/agent-toolkit/latest/userguide/mcp-server.html
   category: other
-  description: "AWS-hosted remote MCP server with access to 15,000+ AWS APIs and Agent SOPs."
+  description: "AWS-hosted MCP server (GA May 6, 2026); 15,000+ AWS APIs via call_aws, server-side Python sandbox via run_script, and on-demand Skills maintained by AWS service teams."
   capabilities:
     - call-aws-api
+    - run-script
     - search-documentation
     - read-documentation
-    - agent-sops
+    - skills
     - recommend
   auth:
     - "AWS IAM (SSO/credentials)"

--- a/tutorials/02-amazon-kiro-cli-cost-analysis.md
+++ b/tutorials/02-amazon-kiro-cli-cost-analysis.md
@@ -156,8 +156,8 @@ uvx --version
 
 ## Step 5: Configure AWS Remote MCP Server for Kiro CLI
 
-**Important**: Complete Tutorial 7 first to set up IAM permissions for the AWS Remote MCP server. You'll need:
-- IAM user with `aws-mcp:InvokeMcp` permission
+**Important**: Complete Tutorial 7 first to set up IAM permissions for the AWS MCP Server. You'll need:
+- IAM user with the policy from Tutorial 7, Step 2 (standard IAM permissions on the underlying AWS actions; the previous `aws-mcp:InvokeMcp` permission was removed at GA on May 6, 2026)
 - AWS profile configured (Step 3 of Tutorial 7)
 
 **Note**: Kiro CLI reads MCP configuration from `~/.kiro/settings/mcp.json`, not from `~/.aws/amazonq/mcp.json`.
@@ -275,7 +275,7 @@ I'm running 10 t3.xlarge instances 24/7. Should I use Reserved Instances or Savi
 
 ### MCP server not loading ("connection closed: initialize response")
 - **Check the correct config file**: Kiro CLI reads from `~/.kiro/settings/mcp.json`, NOT from `~/.aws/amazonq/mcp.json`
-- **Check IAM permissions**: Ensure your IAM user has `aws-mcp:InvokeMcp` permission (see Tutorial 7, Step 2)
+- **Check IAM permissions**: Ensure your IAM user has the policy from Tutorial 7, Step 2 (standard IAM permissions on the underlying AWS actions, e.g. `ce:GetCostAndUsage`, `pricing:GetProducts`)
 - **Verify AWS profile**: Confirm the profile name in `~/.kiro/settings/mcp.json` matches your AWS CLI profile from Tutorial 7
 - **Check the config file**: Ensure `~/.kiro/settings/mcp.json` has valid JSON syntax
 - **Verify uvx is installed**: Run `uvx --version`
@@ -287,7 +287,7 @@ I'm running 10 t3.xlarge instances 24/7. Should I use Reserved Instances or Savi
 - **Check file permissions**: Ensure your user owns the `~/.aws/amazonq/` directory
 
 ### Cost analysis returns authorization errors
-- **IAM Policy**: Verify your IAM user has the `aws-mcp:InvokeMcp` policy attached
+- **IAM Policy**: Verify your IAM user has the policy from Tutorial 7, Step 2 attached (standard IAM permissions on the AWS actions the agent will call)
 - **AWS Profile**: Ensure the profile name in `mcp.json` matches your configured AWS profile
 - **Credentials**: Run `aws configure list --profile mcp-aws` to verify credentials are set
 

--- a/tutorials/07-aws-mcp-remote-server.md
+++ b/tutorials/07-aws-mcp-remote-server.md
@@ -6,16 +6,17 @@
 
 **Tutorial 7 of 7** | ⏱️ **Time**: 20-30 minutes | 💻 **Level**: Beginner
 
-**Last Updated**: March 2026
+**Last Updated**: May 2026
 
 ---
 
 ## 🎯 What You'll Learn
 
 - Set up the official AWS MCP remote server (hosted by AWS)
-- Configure IAM permissions for secure remote access
+- Configure IAM permissions for secure remote access using standard IAM context keys
 - Query AWS APIs, documentation, and resources through natural language
-- Leverage Agent Standard Operating Procedures (SOPs) for AWS tasks
+- Use the `run_script` tool to chain multiple AWS API calls in a single round-trip
+- Leverage Skills for AWS tasks (curated, service-team-maintained guidance)
 
 ---
 
@@ -31,9 +32,11 @@ Previously, you needed to install and maintain separate MCP servers for each AWS
 
 AWS hosts and maintains the entire infrastructure. There's no local installation, no version updates to manage, no dependency conflicts to resolve. The server is always current with the latest AWS APIs, documentation, and best practices. You configure it once in your MCP client and AWS handles everything else - updates, scaling, and reliability.
 
-### Built-in Intelligence with Agent SOPs
+### Built-in Intelligence with Skills
 
-The server includes Agent Standard Operating Procedures (SOPs) - pre-built workflows that encode AWS best practices. When you ask for cost optimization recommendations, the server doesn't just fetch raw data. It applies proven FinOps methodologies, validates commands for accuracy, and structures responses following AWS's recommended patterns. This intelligence accelerates your work from idea to implementation while maintaining security controls and compliance standards.
+The server exposes **Skills** — curated packages of instructions, scripts, and reference material that guide an agent through specific AWS tasks. Skills are contributed and maintained by the individual AWS service teams that own each domain, so the guidance reflects current best practice for that service rather than a generic template. When you ask for cost optimization recommendations, the server can pull the relevant Skill on demand via the `retrieve_skill` tool, which keeps the agent focused on the right APIs and steps without consuming unnecessary context. (When listed by your MCP client, the tools appear with an `aws___` prefix — e.g. `aws___retrieve_skill`, `aws___call_aws`, `aws___run_script`.)
+
+The AWS MCP Server is part of a broader **Agent Toolkit for AWS** — an umbrella that bundles the MCP Server, Skills, Plugins (single-install packages for specific clients), and project-level Rules files.
 
 ### Why It Matters for FinOps
 
@@ -55,6 +58,15 @@ Traditional local MCP servers required you to know which specific server to quer
 ---
 
 ## 🚀 Quick Start
+
+### A note on credential methods
+
+This tutorial uses an **IAM user with static access keys** because they are universally available. AWS recommends two alternatives that auto-rotate credentials and avoid the 90-day key-rotation chore:
+
+- **`aws login`** (AWS CLI 2.32.0+) — for users with AWS Management Console credentials. The SDK rotates credentials every 15 minutes within a session of up to 12 hours.
+- **`aws configure sso`** — for users on AWS IAM Identity Center / SSO. Cached refresh tokens renew silently.
+
+If either is available to you, skip Step 1 below, run the relevant `aws ...` command in Step 3 instead of `aws configure`, and continue with Step 2 onward. Static IAM access keys (the path documented in Step 1 and Step 3) remain valid but will not auto-rotate.
 
 ### Step 1: Create IAM User for MCP Access
 
@@ -93,9 +105,11 @@ Traditional local MCP servers required you to know which specific server to quer
    - ⚠️ **IMPORTANT**: Store these credentials securely - you won't be able to see the secret key again
    - Click **Done**
 
-### Step 2: Attach Required IAM Policy
+### Step 2: Attach IAM Policy
 
-The AWS MCP server requires the `aws-mcp:InvokeMcp` permission to function.
+With the GA release, the AWS MCP Server uses **standard IAM permissions**. There is no separate `aws-mcp:*` action to grant — access is expressed through the same IAM policies you would write for any direct AWS API call. The previous permissions `aws-mcp:InvokeMcp`, `aws-mcp:CallReadOnlyTool`, and `aws-mcp:CallReadWriteTool` no longer have any effect; remove them from any policy where they still appear.
+
+Documentation tools (`search_documentation`, `read_documentation`) require **no authentication** at all. The IAM policy below only governs `call_aws` and `run_script`, which act on AWS resources on the user's behalf.
 
 #### Option A: Using AWS Console
 
@@ -108,9 +122,18 @@ The AWS MCP server requires the `aws-mcp:InvokeMcp` permission to function.
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "FinOpsReadOnly",
       "Effect": "Allow",
       "Action": [
-        "aws-mcp:InvokeMcp"
+        "ce:GetCostAndUsage",
+        "ce:GetCostForecast",
+        "ce:GetDimensionValues",
+        "ce:GetTags",
+        "pricing:GetProducts",
+        "ec2:Describe*",
+        "s3:List*",
+        "cloudwatch:Get*",
+        "cloudwatch:List*"
       ],
       "Resource": "*"
     }
@@ -120,6 +143,8 @@ The AWS MCP server requires the `aws-mcp:InvokeMcp` permission to function.
 
 4. Name the policy: `AWSMCPAccess`
 5. Click **Create policy**
+
+Because the user we created in Step 1 is dedicated to MCP, a plain `Allow` is enough. The same credentials can still be used with the AWS CLI (useful for the validation step in Step 3), and CloudTrail will record whether each call came through the MCP Server or directly.
 
 #### Option B: Using AWS CLI
 
@@ -131,13 +156,46 @@ aws iam put-user-policy \
     "Version": "2012-10-17",
     "Statement": [
       {
+        "Sid": "FinOpsReadOnly",
         "Effect": "Allow",
-        "Action": ["aws-mcp:InvokeMcp"],
+        "Action": [
+          "ce:GetCostAndUsage",
+          "ce:GetCostForecast",
+          "ce:GetDimensionValues",
+          "ce:GetTags",
+          "pricing:GetProducts",
+          "ec2:Describe*",
+          "s3:List*",
+          "cloudwatch:Get*",
+          "cloudwatch:List*"
+        ],
         "Resource": "*"
       }
     ]
   }'
 ```
+
+#### Optional: Telling MCP-initiated calls apart from direct API calls
+
+AWS adds two global condition context keys to every request the MCP Server makes for you:
+
+- `aws:ViaAWSMCPService` — **Boolean**, set to `true` for any request through an AWS managed MCP server.
+- `aws:CalledViaAWSMCP` — **String**, contains the service principal of the specific MCP server (for example, `aws-mcp.amazonaws.com`).
+
+If the IAM identity is shared between human and agent use, you can use these keys in `Deny` statements to keep the agent narrower than the human. For example, to block destructive S3 operations specifically when called through any AWS managed MCP server:
+
+```json
+{
+  "Effect": "Deny",
+  "Action": ["s3:DeleteBucket", "s3:DeleteObject"],
+  "Resource": "*",
+  "Condition": {
+    "Bool": {"aws:ViaAWSMCPService": "true"}
+  }
+}
+```
+
+CloudTrail captures both keys, so the same conditions can be used to filter MCP-initiated activity in audit logs.
 
 ### Step 3: Configure AWS Credentials
 
@@ -195,6 +253,10 @@ export AWS_REGION="us-east-1"
 ```
 
 **Note**: Environment variables set this way are temporary and only last for the current PowerShell/terminal session. For persistent credentials, use Option A (AWS Profile) instead.
+
+### About `mcp-proxy-for-aws`
+
+The configurations below all start with `uvx mcp-proxy-for-aws@latest`. That invokes the [MCP Proxy for AWS](https://github.com/aws/mcp-proxy-for-aws) — a small open-source program that runs locally on your machine. It bridges between the STDIO transport your MCP client speaks and the HTTPS endpoint where the AWS MCP Server lives, and it signs each request with SigV4 using the AWS profile from Step 3. You don't install it manually; `uvx` downloads and runs the latest version each time your MCP client starts. If you hit credential or signing errors, the proxy is the component handling that part of the flow.
 
 ### Step 4: Install and Configure MCP Client
 
@@ -273,7 +335,7 @@ Add the `aws-mcp` server to your existing `mcpServers` object. If you already ha
 - `mcp-aws` is the AWS profile name you created in Step 3 with `aws configure --profile mcp-aws`
 - If you used a different profile name in Step 3, replace `mcp-aws` with your chosen profile name
 - This tutorial uses `us-east-1` (North Virginia). You can change to your preferred AWS region
-- The server endpoint is always `https://aws-mcp.us-east-1.api.aws/mcp` (hosted in us-east-1)
+- Two regional endpoints are available at GA: `https://aws-mcp.us-east-1.api.aws/mcp` (US East / N. Virginia) and `https://aws-mcp.eu-central-1.api.aws/mcp` (Europe / Frankfurt). Pick the one closest to you for lower latency — both can call APIs in any region. EU-based teams will typically prefer the Frankfurt endpoint.
 
 3. **Restart Claude Desktop**
 
@@ -321,6 +383,26 @@ claude-code config mcp add aws-mcp \
 ```
 
 **Note**: `mcp-aws` is the AWS profile name from Step 3. If you used a different profile name, replace it in the `--env` parameter.
+
+---
+
+### Step 5: Multi-Step FinOps Workflows with `run_script`
+
+The GA release introduces a `run_script` tool that runs short Python scripts in a server-side sandbox. The script inherits the caller's IAM permissions, has no network access outside AWS, and lets the agent chain multiple AWS API calls in a single round-trip rather than making one MCP call per operation.
+
+For FinOps workflows that touch many APIs, this matters. A "top services by month-over-month growth" analysis would otherwise require many separate `call_aws` round-trips. With `run_script`, the agent generates one Python script that pulls the data, computes the deltas locally, and returns only the ranked result.
+
+**Example prompt**:
+
+```
+Pull Cost Explorer data for the last 30 days and the prior 30 days,
+then return the top 5 AWS services by month-over-month growth as a
+ranked list with absolute and percentage change.
+```
+
+In response, the agent writes a single script that calls `GetCostAndUsage` for both periods, aggregates by service, sorts by delta, and returns the top 5 — replacing what would otherwise be several turns of back-and-forth and reducing both latency and token usage.
+
+The script runs in an isolated sandbox: no network egress outside AWS, no persistent state between invocations, and only the IAM permissions you have granted to the user or role. For most FinOps work — cost aggregation, trend analysis, commitment portfolio reviews — `run_script` is more efficient than orchestrating dozens of individual API calls from the client side.
 
 ---
 
@@ -379,7 +461,7 @@ Analyze my AWS resources in us-east-1 and suggest cost optimization opportunitie
 
 The AI will:
 - Query your resources using AWS APIs
-- Access AWS optimization best practices (SOPs)
+- Pull the relevant Skills for cost optimization
 - Provide actionable recommendations
 - Estimate potential savings
 
@@ -406,7 +488,7 @@ Should I purchase Reserved Instances for my EC2 workloads?
 The AI will:
 - Analyze your EC2 usage patterns
 - Access AWS pricing documentation
-- Apply RI recommendation SOPs
+- Apply the relevant Reserved Instance Skill
 - Provide purchase recommendations with ROI calculations
 
 ---
@@ -429,23 +511,24 @@ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 
 Then restart your terminal and MCP client.
 
-### Issue: "Not authorized to perform aws-mcp:InvokeMcp"
+### Issue: "AccessDenied" on `call_aws` or `run_script`
 
-**Solution**: Check IAM permissions:
+**Solution**: Check IAM permissions on the underlying AWS action — there is no separate `aws-mcp:*` permission to grant since GA.
 
-1. Verify policy is attached to your user:
+1. Verify the policy is attached to your user:
 ```bash
 aws iam list-user-policies --user-name mcp-aws-user
 ```
 
-2. Get policy document:
+2. Get the policy document:
 ```bash
 aws iam get-user-policy \
   --user-name mcp-aws-user \
   --policy-name AWSMCPAccess
 ```
 
-3. Ensure it includes `aws-mcp:InvokeMcp` action
+3. Confirm the `Action` list covers the AWS API the agent is calling (e.g. `ce:GetCostAndUsage`, `pricing:GetProducts`).
+4. If you used a `Condition` block with `aws:ViaAWSMCPService`, confirm the call is actually arriving through the MCP Server and not directly via the CLI/SDK.
 
 ### Issue: "Invalid credentials" or "Access Denied"
 
@@ -474,20 +557,14 @@ cat ~/.aws/config
 
 ### Principle of Least Privilege
 
-For production use, extend the IAM policy to grant only the specific AWS permissions needed:
+For production use, scope the IAM policy to the specific AWS actions your agent needs. If the same IAM identity is used for both human and agent activity, follow the AWS-documented pattern of an explicit `Deny` for actions you don't want the agent to perform, scoped via the `aws:ViaAWSMCPService` (or `aws:CalledViaAWSMCP`) context key:
 
 ```json
 {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
-      "Action": [
-        "aws-mcp:InvokeMcp"
-      ],
-      "Resource": "*"
-    },
-    {
+      "Sid": "FinOpsReadOnlyAllow",
       "Effect": "Allow",
       "Action": [
         "ec2:Describe*",
@@ -500,6 +577,21 @@ For production use, extend the IAM policy to grant only the specific AWS permiss
         "cloudwatch:List*"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "BlockDestructiveActionsViaMCP",
+      "Effect": "Deny",
+      "Action": [
+        "ec2:Terminate*",
+        "ec2:Stop*",
+        "rds:Delete*",
+        "s3:DeleteBucket",
+        "s3:DeleteObject"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Bool": {"aws:ViaAWSMCPService": "true"}
+      }
     }
   ]
 }
@@ -590,11 +682,12 @@ Found a problem with this tutorial?
 ## ✨ Summary
 
 **What you accomplished**:
-- ✅ Set up AWS IAM user with MCP permissions
+- ✅ Set up an AWS IAM user with standard, least-privilege FinOps permissions
 - ✅ Configured AWS credentials securely
-- ✅ Connected to AWS's first remote MCP server
+- ✅ Connected to the AWS MCP Server (now generally available)
 - ✅ Accessed 15,000+ AWS APIs through natural language
-- ✅ Tested FinOps workflows with Agent SOPs
+- ✅ Used `run_script` to chain multiple AWS calls in a single round-trip
+- ✅ Tested FinOps workflows backed by service-team-maintained Skills
 
 **Key takeaway**: The AWS MCP remote server eliminates local installation complexity while providing comprehensive, managed access to all AWS services, documentation, and best practices - perfect for production FinOps workflows.
 


### PR DESCRIPTION
## Summary
- Reflects the **AWS MCP Server reaching general availability on May 6, 2026** as part of the broader Agent Toolkit for AWS (Server + Skills + Plugins + Rules files).
- Replaces the retired `aws-mcp:InvokeMcp` / `aws-mcp:CallReadOnlyTool` / `aws-mcp:CallReadWriteTool` permissions with standard IAM policies, plus the new `aws:ViaAWSMCPService` (Bool) and `aws:CalledViaAWSMCP` (String) global condition context keys. IAM examples follow the AWS-documented `Deny`-style scoping pattern.
- Documents the new `run_script` (server-side Python sandbox) and `retrieve_skill` tools, the `aws___` tool-name prefix used by MCP clients, the Frankfurt (`eu-central-1`) endpoint alongside `us-east-1`, the unauthenticated documentation tools, the CloudWatch `AWS-MCP` namespace + CloudTrail observability story, and pricing (no charge for the server itself).
- Replaces "Agent SOPs" with **Skills** (now contributed and maintained by individual AWS service teams).
- Adds an explanation of the **MCP Proxy for AWS** (the local STDIO-to-HTTPS bridge that handles SigV4 signing — invoked via `uvx mcp-proxy-for-aws@latest`) and a credential-method note recommending `aws login` and `aws configure sso` over static IAM access keys when available.
- Cleans up stale `aws-mcp:InvokeMcp` / "Agent SOPs" references in `tutorials/02-amazon-kiro-cli-cost-analysis.md` and `servers/configs/registry.yaml`.

## Files changed
- `tutorials/07-aws-mcp-remote-server.md` (primary rewrite around GA model)
- `servers/aws.md` (GA section promoted; preview block removed; capabilities, pricing, observability, Frankfurt endpoint, proxy explanation added)
- `governance/remote-mcp-servers.md` (one-sentence GA note)
- `README.md` (Recent Updates → May 2026)
- `CHANGELOG.md` (new May 2026 entry)
- `tutorials/02-amazon-kiro-cli-cost-analysis.md` (stale references)
- `servers/configs/registry.yaml` (entry refresh)

## Test plan
- [x] Frankfurt endpoint verified against the live AWS user guide setup doc: `https://aws-mcp.eu-central-1.api.aws/mcp` ✓
- [x] IAM context key names verified against the live AWS user guide: `aws:ViaAWSMCPService` and `aws:CalledViaAWSMCP` ✓
- [x] All retired permission names verified: `aws-mcp:InvokeMcp`, `aws-mcp:CallReadOnlyTool`, `aws-mcp:CallReadWriteTool` ✓
- [ ] Render check on GitHub (Markdown formatting, code fences, link targets)
- [ ] Spot-check tutorial 07 by following the updated steps in a fresh AWS account

🤖 Generated with [Claude Code](https://claude.com/claude-code)