### PR TITLE
Add nable (finops-mcp): local-first multi-cloud FinOps MCP server

### DIFF
--- a/servers/INDEX.md
+++ b/servers/INDEX.md
@@ -1,8 +1,8 @@
 # MCP Servers for Cloud FinOps and Cost Optimization
 
-**Last Updated**: May 2026
+**Last Updated**: June 2026
 
-A curated registry of 18 MCP servers for cloud cost optimization, FinOps automation, and AI-powered cost management across AWS, Azure, and GCP. Includes cloud provider billing servers, tagging governance tools, and workflow integrations (JIRA, Slack).
+A curated registry of 19 MCP servers for cloud cost optimization, FinOps automation, and AI-powered cost management across AWS, Azure, and GCP. Includes cloud provider billing servers, tagging governance tools, and workflow integrations (JIRA, Slack).
 
 See [`configs/registry.yaml`](./configs/registry.yaml) for the machine-readable registry.
 
@@ -18,6 +18,9 @@ See [`configs/registry.yaml`](./configs/registry.yaml) for the machine-readable 
 
 ### GCP Cloud Cost Servers
 - **[GCP MCP Servers](./gcp.md)** — BigQuery billing exports, Compute Engine, GKE, community servers
+
+### Multi-cloud Cost Servers
+- **[nable (finops-mcp)](https://github.com/chaandannn/finopsmcp)** — Local-first server for AWS, Azure and GCP plus AI and SaaS spend: cost queries, anomaly detection, rightsizing, LLM token tracking
 
 ### Workflow & Collaboration
 - **[FinOps Tagging Compliance](./tagging.md)** — Tag compliance checking, drift detection, cost attribution gap analysis

--- a/servers/configs/registry.yaml
+++ b/servers/configs/registry.yaml
@@ -317,7 +317,7 @@
     - get-commitment-recommendations
   auth:
     - "Cloud provider credentials (stored in OS keyring, never leave the machine)"
-  maturity: ga
+  maturity: beta
   security_notes: "Read-only cost APIs; credentials encrypted locally; no vendor backend, nothing leaves the user's machine."
   tags:
     - finops

--- a/servers/configs/registry.yaml
+++ b/servers/configs/registry.yaml
@@ -276,6 +276,33 @@
     - bigquery
     - community
 
+# ── Multi-cloud ──────────────────────────────────────────
+
+- name: nable-finops-mcp
+  provider: Multi-cloud
+  repo: https://github.com/chaandannn/finopsmcp
+  homepage: https://getnable.com
+  category: reporting
+  description: "Local-first FinOps server: cost queries, anomaly detection and rightsizing across AWS, Azure, GCP plus AI (OpenAI, Anthropic, Bedrock) and SaaS spend."
+  capabilities:
+    - get-cost-summary
+    - explain-cost-drivers
+    - detect-anomalies
+    - get-rightsizing-recommendations
+    - track-llm-spend-by-model
+    - get-commitment-recommendations
+  auth:
+    - "Cloud provider credentials (stored in OS keyring, never leave the machine)"
+  maturity: ga
+  security_notes: "Read-only cost APIs; credentials encrypted locally; no vendor backend, nothing leaves the user's machine."
+  tags:
+    - finops
+    - multi-cloud
+    - aws
+    - azure
+    - gcp
+    - ai-costs
+
 # ── Workflow & Collaboration ─────────────────────────────
 
 - name: finops-tagging-mcp


### PR DESCRIPTION
Adds nable (PyPI: finops-mcp), a local-first FinOps MCP server covering AWS, Azure and GCP plus AI providers (OpenAI, Anthropic, Bedrock) and SaaS spend (Datadog, Snowflake, Stripe). Cost queries, anomaly detection, rightsizing and LLM token spend per model. Runs entirely on the user's machine; credentials stay in the OS keyring and there is no vendor backend.

Since the registry had no multi-cloud section, this adds one between GCP and Workflow & Collaboration; happy to re-file it differently if you prefer.

Testing notes per CONTRIBUTING: installed via `uvx --from finops-mcp finops welcome` on macOS, used with Claude Desktop and Cursor against a live AWS account. Also published in the official MCP registry.

Repo: https://github.com/chaandannn/finopsmcp
Site: https://getnable.com

Disclosure: I am the author of nable.
