### PR TITLE
Refresh Azure docs for official FinOps MCP Server preview (June 2026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [July 2026] - 2026-07-13
+
+### Changed
+- **Azure FinOps MCP Server (public preview)** — Refreshed all Azure documentation for Microsoft's June 23, 2026 announcement ([From insight to action](https://azure.microsoft.com/en-us/blog/from-insight-to-action-the-next-phase-of-agentic-cloud-operations/)). The claim that "the official Azure MCP server does NOT expose cost management or billing APIs" is retired: (1) the **ARM MCP Server** (public preview since May 7, 2026, branded **Azure FinOps MCP Server** for cost workflows) gives agents natural-language Azure Resource Graph queries with cost and usage intelligence rolling out; (2) `@azure/mcp` gained a **retail pricing tool** (list prices, reservation and savings plan rates — cost estimation, not actual spend). Updated `servers/azure.md`, `tutorials/04-azure-mcp-quickstart.md`, `servers/INDEX.md`, and `servers/configs/registry.yaml`.
+- **Recommendation reframed** — julianobarbosa/azure-finops-mcp-server stays the most direct path to actual Cost Management (billing) data today; the official ARM/FinOps MCP Server is the one to watch (currently requires VS Code + GitHub Copilot; Claude support announced as next).
+- **Governance note added** — the ARM MCP Server is NOT read-only: it ships ARM template deployment tools alongside its query tools. Docs now recommend Reader + Resource Graph scoping and/or disabling deployment tools for FinOps-only use (Azure Policy can block MCP-initiated deployments).
+- **finopshub-mcp guidance** — now points to Microsoft's official [Configure AI agents for FinOps hubs](https://learn.microsoft.com/en-us/cloud-computing/finops/toolkit/hubs/configure-ai) path as the preferred alternative to the proof-of-concept server.
+- **Broken link fixed** — `servers/azure.md` and `tutorials/04-azure-mcp-quickstart.md` pointed to a non-existent `governance/security-privileges-azure.md`; both now link to the governance INDEX.
+
+### Added
+- **`arm-mcp-server` registry entry** in `servers/configs/registry.yaml` (maturity: preview, 6 tools: 3 ARG query + 3 ARM deployment) — registry now has 18 entries; documented server count bumped to 19 in README/INDEX.
+
 ## [May 2026] - 2026-05-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 A practical resource hub for FinOps practitioners, cloud engineers, and platform teams who want to use **AI agents** to automate cloud cost optimization. This repo provides tutorials, MCP server documentation, client guides, and security frameworks for implementing the Model Context Protocol across AWS, Azure, and GCP.
 
-**18 MCP servers documented** | **7 step-by-step tutorials** | **9 MCP clients compared** | **3 cloud providers covered**
+**19 MCP servers documented** | **7 step-by-step tutorials** | **9 MCP clients compared** | **3 cloud providers covered**
 
 ---
 
@@ -40,7 +40,7 @@ A practical resource hub for FinOps practitioners, cloud engineers, and platform
 | Section | What you'll find |
 |---------|-----------------|
 | [/foundations](./foundations) | What is MCP, how it works, architecture deep-dive |
-| [/servers](./servers) | 18 MCP servers — AWS, Azure, GCP, Tagging, JIRA, Slack |
+| [/servers](./servers) | 19 MCP servers — AWS, Azure, GCP, Tagging, JIRA, Slack |
 | [/clients](./clients) | 9 MCP clients compared — Claude, ChatGPT, Gemini, Copilot, Cursor, Kiro |
 | [/tutorials](./tutorials) | 7 step-by-step guides for AWS, Azure, GCP cost analysis |
 | [/governance](./governance) | Security best practices, IAM policies, vulnerability guides |

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ A practical resource hub for FinOps practitioners, cloud engineers, and platform
 
 ---
 
-## Recent Updates (May 2026)
+## Recent Updates (July 2026)
 
+- **Azure FinOps MCP Server (public preview)** (June 23, 2026) — Microsoft's first official FinOps-branded MCP server, the cost-and-usage packaging of the **ARM MCP Server** (preview since May 7). Natural-language Azure Resource Graph queries for estate-wide waste detection; the official `@azure/mcp` server also gained a retail pricing tool for pre-deployment cost estimation. Updated: [server doc](./servers/azure.md), [tutorial](./tutorials/04-azure-mcp-quickstart.md). Source: [Azure Blog](https://azure.microsoft.com/en-us/blog/from-insight-to-action-the-next-phase-of-agentic-cloud-operations/).
 - **AWS MCP Server GA** (May 6, 2026) — Now part of the broader Agent Toolkit for AWS. The previous `aws-mcp:InvokeMcp` permission is replaced by standard IAM policies using the `aws:ViaAWSMCPService` and `aws:CalledViaAWSMCP` context keys. New `run_script` tool runs short Python scripts in a server-side sandbox for multi-step workflows. Frankfurt (`eu-central-1`) endpoint added alongside `us-east-1`. Updated: [tutorial](./tutorials/07-aws-mcp-remote-server.md), [server doc](./servers/aws.md).
 - **Google managed MCP servers GA** (April 29, 2026): more than 50 official Google MCP servers across infrastructure, databases, analytics, storage, and Workspace APIs (BigQuery, Cloud Run, Apigee, AlloyDB, Spanner, Firestore, GKE). Updated: [server doc](./servers/gcp.md).
 - **New: Workflow & Collaboration Servers** — [FinOps Tagging Compliance](./servers/tagging.md), [JIRA](./servers/jira.md), and [Slack](./servers/slack.md) MCP servers for automated cost governance
-- **Registry Backfill** — [`registry.yaml`](./servers/configs/registry.yaml) now lists all 18 documented MCP servers
+- **Registry Backfill** — [`registry.yaml`](./servers/configs/registry.yaml) machine-readable registry, now at 18 entries with the ARM MCP Server addition
 - **MCP Authentication Vulnerabilities** (refreshed May 2026): critical security risks plus 2 new 2026 CVEs (CVE-2026-0621 in the TypeScript SDK, CVE-2026-40933 in Flowise) ([read more](./governance/mcp-authentication-vulnerabilities-2026.md))
 - **MCP Dev Summit North America 2026** (NYC): AAIF reported 1,200 attendees, 110+ million monthly SDK downloads, and 170 member organizations. Headline disclosures: a DNS rebinding attack class against MCP servers (Jonathan Leitschuh / Braise) and Amazon's "lethal trifecta" pattern for scanning agent configurations. Source: [AAIF blog](https://aaif.io/blog/mcp-is-now-enterprise-infrastructure-everything-that-happened-at-mcp-dev-summit-north-america-2026/)
 

--- a/llms.txt
+++ b/llms.txt
@@ -38,7 +38,7 @@ A comprehensive resource hub for FinOps practitioners, cloud engineers, and plat
 - [FinOps Tagging Compliance](servers/tagging.md): Tag compliance checking, drift detection, cost allocation
 - [JIRA for FinOps](servers/jira.md): Cost anomaly ticketing, optimization tracking workflows
 - [Slack for FinOps](servers/slack.md): Cost alerts, budget notifications, team collaboration
-- [Server Registry (YAML)](servers/configs/registry.yaml): Machine-readable registry of all 18 servers
+- [Server Registry (YAML)](servers/configs/registry.yaml): Machine-readable registry of documented servers
 
 ### MCP Clients (AI Interfaces)
 - [Client Comparison](clients/comparison.md): Which MCP client to choose for FinOps

--- a/servers/INDEX.md
+++ b/servers/INDEX.md
@@ -1,8 +1,8 @@
 # MCP Servers for Cloud FinOps and Cost Optimization
 
-**Last Updated**: May 2026
+**Last Updated**: July 2026
 
-A curated registry of 18 MCP servers for cloud cost optimization, FinOps automation, and AI-powered cost management across AWS, Azure, and GCP. Includes cloud provider billing servers, tagging governance tools, and workflow integrations (JIRA, Slack).
+A curated registry of 19 MCP servers for cloud cost optimization, FinOps automation, and AI-powered cost management across AWS, Azure, and GCP. Includes cloud provider billing servers, tagging governance tools, and workflow integrations (JIRA, Slack).
 
 See [`configs/registry.yaml`](./configs/registry.yaml) for the machine-readable registry.
 
@@ -14,7 +14,7 @@ See [`configs/registry.yaml`](./configs/registry.yaml) for the machine-readable 
 - **[AWS MCP Servers](./aws.md)** — Remote server (15,000+ APIs), Pricing API, Cost Explorer, CloudWatch, Billing & Cost Management, CFM Tips
 
 ### Azure Cloud Cost Servers
-- **[Azure MCP Servers](./azure.md)** — Official @azure/mcp, community FinOps server (recommended for cost analysis)
+- **[Azure MCP Servers](./azure.md)** — 🆕 Official ARM / Azure FinOps MCP Server (public preview), @azure/mcp with retail pricing, community FinOps server for billing data
 
 ### GCP Cloud Cost Servers
 - **[GCP MCP Servers](./gcp.md)** — BigQuery billing exports, Compute Engine, GKE, community servers

--- a/servers/azure.md
+++ b/servers/azure.md
@@ -1,39 +1,52 @@
 # Azure MCP Servers for Cloud Cost Management
 
-**Last Updated**: May 2026
+**Last Updated**: July 2026
 
-A guide to Azure MCP servers for FinOps, cloud cost management, and AI-powered cost analysis. Covers the official Azure MCP server and community alternatives for cost optimization and billing workflows.
+A guide to Azure MCP servers for FinOps, cloud cost management, and AI-powered cost analysis. Covers the official Azure MCP servers (including the new ARM / FinOps MCP Server preview) and community alternatives for cost optimization and billing workflows.
+
+> **🆕 What changed in mid-2026:** Microsoft now has an official FinOps story for MCP. On June 23, 2026, Azure announced the **Azure FinOps MCP Server (public preview)** — the FinOps-facing packaging of the **Azure Resource Manager (ARM) MCP Server** (public preview since May 2026) — to "connect cost and usage intelligence into agent workflows." Separately, the official `@azure/mcp` server gained an **Azure retail pricing tool** for cost estimation. See [From insight to action](https://azure.microsoft.com/en-us/blog/from-insight-to-action-the-next-phase-of-agentic-cloud-operations/) and [Introducing the ARM MCP Server](https://techcommunity.microsoft.com/blog/azuregovernanceandmanagementblog/introducing-the-azure-resource-manager-mcp-server/4517521).
 
 ## Which Azure MCP server should I use for FinOps?
 
-The **official Azure MCP server** (`@azure/mcp`) provides Azure resource management and monitoring, but **does NOT expose cost management or billing APIs**. For FinOps and cost analysis, use the community alternatives below.
+Until mid-2026, no official Microsoft MCP server exposed cost APIs — that is no longer true, but the picture is nuanced:
+
+- The **official `@azure/mcp` server** now includes a **retail pricing tool** (list prices, reservation and savings plan rates) — good for **cost estimation before deployment**, but it still does **not** expose your actual spend (Cost Management / billing data).
+- The **official ARM MCP Server** (branded **Azure FinOps MCP Server** for cost workflows, public preview) gives agents natural-language **Azure Resource Graph** queries across your whole estate — powerful for inventory-driven waste detection (orphaned disks, unattached IPs, untagged resources) — with cost and usage intelligence rolling out under the FinOps branding.
+- For querying your **actual cost/billing data today**, the community **azure-finops-mcp-server** remains the most direct option.
 
 ## Available Azure MCP Servers
 
 | **Server Name** | **Official?** | **Type** | **Cost/Billing APIs?** | **Production Ready?** | **Install** |
 |:----------------|:--------------|:---------|:----------------------|:---------------------|:------------|
-| [**@azure/mcp**](https://github.com/Azure/azure-mcp) | ✅ Yes (Microsoft) | Remote | ❌ No | ✅ Yes | [![Install VS Code](https://img.shields.io/badge/Install-VS%20Code-blue?logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=Azure%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40azure%2Fmcp%40latest%22%2C%22server%22%2C%22start%22%5D%7D) |
-| [**azure-finops-mcp-server**](https://github.com/julianobarbosa/azure-finops-mcp-server) ⭐ **Recommended for FinOps** | ❌ No (Community) | Local | ✅ Yes | ✅ Yes | `uv pip install azure-finops-mcp-server` |
+| [**ARM MCP Server**](https://github.com/Azure/Azure-Resource-Manager-MCP) (aka **Azure FinOps MCP Server**) 🆕 | ✅ Yes (Microsoft) | Remote | 🟡 Rolling out (preview) | 🟡 Public preview | Open [aka.ms/JoinARMMCP](https://aka.ms/JoinARMMCP) in VS Code |
+| [**@azure/mcp**](https://github.com/Azure/azure-mcp) | ✅ Yes (Microsoft) | Remote | ⚠️ Retail pricing only (no billing data) | ✅ Yes | [![Install VS Code](https://img.shields.io/badge/Install-VS%20Code-blue?logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=Azure%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40azure%2Fmcp%40latest%22%2C%22server%22%2C%22start%22%5D%7D) |
+| [**azure-finops-mcp-server**](https://github.com/julianobarbosa/azure-finops-mcp-server) ⭐ **Recommended for billing data today** | ❌ No (Community) | Local | ✅ Yes (Cost Management) | ✅ Yes | `uv pip install azure-finops-mcp-server` |
 | [**finopshub-mcp**](https://github.com/mc5eamus/finopshub-mcp) | ❌ No (Community) | Local | ✅ Yes | ❌ No (Proof-of-concept) | Clone + manual setup |
 
 ### Which Server Should You Use?
 
-**For resource management and monitoring**: Use the **official @azure/mcp** server. It provides access to Azure subscriptions, resource groups, storage, AKS, logs, metrics, and diagnostics. Easy to install via `npx`, officially supported by Microsoft.
+**For estate-wide inventory and waste detection (official, preview)**: Use the **ARM MCP Server**. It generates, validates, and executes Azure Resource Graph queries from natural language ("show me all disks not attached to a VM", "find resources created in the last 30 days without required tags") — the backbone of inventory-driven FinOps. Azure is expanding it with cost and usage intelligence under the **Azure FinOps MCP Server** branding. Caveats: it currently requires **VS Code + GitHub Copilot** (Claude support announced as next), and it also includes **ARM template deployment tools** — see the governance note below.
 
-**For FinOps/cost analysis**: Use **julianobarbosa/azure-finops-mcp-server** (community, but production-ready):
+**For pre-deployment cost estimation (official)**: Use the **@azure/mcp** server's [pricing tool](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-pricing) — retail prices by SKU/region, including reservation and savings plan rates. Also your go-to for resource management and monitoring (subscriptions, resource groups, storage, AKS, logs, metrics, diagnostics).
+
+**For actual cost/billing analysis today**: Use **julianobarbosa/azure-finops-mcp-server** (community, but production-ready):
 - 97.7% test coverage, 100% architecture compliance
 - GitHub Actions CI/CD pipeline
 - 4.9x faster performance with parallel processing
 - Secure (credentials remain local via Azure CLI)
 - Features: `get_cost` (cost analysis with tag filtering) and `run_finops_audit` (unused resource detection)
 
-**Avoid finopshub-mcp** unless experimenting: early proof-of-concept with no test coverage or CI/CD pipeline.
+**For FinOps hubs users**: Microsoft's official path is to connect AI agents to your hub's Data Explorer via the Azure MCP server — see [Configure AI agents for FinOps hubs](https://learn.microsoft.com/en-us/cloud-computing/finops/toolkit/hubs/configure-ai). **Avoid finopshub-mcp** unless experimenting: early proof-of-concept with no test coverage or CI/CD pipeline, largely superseded by the official guidance.
 
-
+> **⚠️ Governance note on the ARM MCP Server:** unlike the read-only community FinOps servers, the ARM MCP Server ships **write tools** (`create_template_deployment`, `cancel_arm_template_deployment`) alongside its Resource Graph query tools. All operations run under the signed-in user's RBAC, and Microsoft documents using Azure Policy to block deployments via the MCP server. For FinOps use, run it with a **Reader + Resource Graph-scoped identity** and/or disable the deployment tools in your MCP client.
 
 ---
 
 ## ⚙️ Prerequisites
+
+### For Official ARM MCP Server (public preview):
+- **VS Code** with a **GitHub Copilot subscription** (other clients, including Claude, announced as coming)
+- Valid **Azure account**; sign-in happens on install via [aka.ms/JoinARMMCP](https://aka.ms/JoinARMMCP)
 
 ### For Official @azure/mcp Server:
 - An **Azure subscription**
@@ -50,18 +63,30 @@ The **official Azure MCP server** (`@azure/mcp`) provides Azure resource managem
 
 ## 🔐 Required Azure Permissions
 
+**For official ARM MCP Server**:
+- **Reader** + **Resource Graph** read access on the target scope for query tools
+- **Contributor** on target resource groups only if you intend to use the deployment tools (not recommended for FinOps-only use)
+- All operations execute as the signed-in user — the agent's permissions are exactly your permissions
+
 **For official @azure/mcp**:
-- **Reader** role at subscription or resource group level
+- **Reader** role at subscription or resource group level (retail pricing queries need no billing permissions — they hit public price lists)
 
 **For community FinOps servers**:
 - **Cost Management Reader** role on the subscription to allow cost and usage queries
 - Optionally, **Reader** role on resource groups for detailed resource-level insights
 
-👉 See [full Azure MCP IAM/RBAC guidance](../governance/security-privileges-azure.md) for details.
+👉 See the [governance section](../governance/INDEX.md) for security best practices and IAM guidance.
 
 ---
 
 ## 🛠 Configuration Examples
+
+### Official ARM MCP Server (public preview)
+
+1. Open [https://aka.ms/JoinARMMCP](https://aka.ms/JoinARMMCP) — VS Code launches automatically
+2. Click **Install** under *Azure Resource Manager MCP Server*
+3. Sign in with your Azure credentials
+4. In VS Code Chat, open **Configure Tools** and enable the six ARM MCP tools (for FinOps-only use, consider leaving the three deployment tools disabled)
 
 ### Official @azure/mcp Server
 
@@ -95,4 +120,4 @@ Then configure in your MCP client settings. See the [azure-finops-mcp-server doc
 
 ## 📚 Tutorials
 
-- [Azure MCP Quickstart Tutorial](../tutorials/04-azure-mcp-quickstart.md) - Step-by-step guide with Cline setup and comparison of all three servers
+- [Azure MCP Quickstart Tutorial](../tutorials/04-azure-mcp-quickstart.md) - Step-by-step guide with Cline setup and comparison of all four servers

--- a/servers/configs/registry.yaml
+++ b/servers/configs/registry.yaml
@@ -148,6 +148,29 @@
 
 # ── Azure ────────────────────────────────────────────────
 
+- name: arm-mcp-server
+  provider: Azure
+  repo: https://github.com/Azure/Azure-Resource-Manager-MCP
+  category: governance
+  description: "Official Microsoft ARM MCP server (branded 'Azure FinOps MCP Server' for cost workflows, public preview): natural-language Azure Resource Graph queries plus ARM template deployment tools; cost and usage intelligence rolling out per the June 2026 Azure announcement."
+  capabilities:
+    - generate-query
+    - validate-query
+    - execute-query
+    - create-template-deployment
+    - get-deployment-status
+    - cancel-deployment
+  auth:
+    - "Signed-in Azure user (VS Code + GitHub Copilot; Claude support announced)"
+  maturity: preview
+  security_notes: "Official Microsoft server; runs under the signed-in user's RBAC. NOT read-only — includes ARM deployment tools; for FinOps-only use, scope identity to Reader + Resource Graph and disable deployment tools, or block deployments via Azure Policy."
+  tags:
+    - finops
+    - azure
+    - resource-graph
+    - governance
+    - preview
+
 - name: azure-finops-mcp-server
   provider: Azure
   repo: https://github.com/julianobarbosa/azure-finops-mcp-server
@@ -170,16 +193,17 @@
   provider: Azure
   repo: https://github.com/Azure/azure-mcp
   category: other
-  description: "Official Microsoft Azure MCP server for resource management and monitoring (no cost/billing APIs)."
+  description: "Official Microsoft Azure MCP server for resource management, monitoring, and retail pricing lookups (no actual cost/billing data)."
   capabilities:
     - manage-resources
     - query-resource-graph
     - monitor-metrics
     - manage-storage
+    - get-retail-pricing
   auth:
     - "Azure credentials (CLI/service principal)"
   maturity: ga
-  security_notes: "Official Microsoft server; Reader role required; does NOT expose cost management APIs."
+  security_notes: "Official Microsoft server; Reader role required; retail pricing tool covers list prices and savings plan rates only — does NOT expose Cost Management (actual spend) APIs."
   tags:
     - azure
     - resource-management

--- a/tutorials/04-azure-mcp-quickstart.md
+++ b/tutorials/04-azure-mcp-quickstart.md
@@ -6,7 +6,7 @@
 
 **Tutorial 4 of 7** | ⏱️ **Time**: 20-30 minutes | 💻 **Level**: Beginner
 
-**Last Updated**: May 2026
+**Last Updated**: July 2026
 
 ---
 
@@ -24,7 +24,7 @@
 
 The **official Azure MCP server** (`@azure/mcp`) is a **remote MCP server** that provides Azure resource management and monitoring capabilities. This means it runs via `npx` and automatically downloads the latest version from npm—no local installation needed.
 
-**⚠️ Important Limitation:** The official Azure MCP server **does NOT currently expose cost management or billing APIs**. For FinOps/cost analysis, see the comparison table in section 6 for community alternatives.
+**⚠️ Important Nuance (updated July 2026):** The official Azure MCP server now includes a **retail pricing tool** ([docs](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-pricing)) — list prices by SKU/region, including reservation and savings plan rates — useful for **cost estimation before deployment**. It still does **NOT expose your actual spend** (Cost Management / billing data). For actual cost analysis, see the comparison table in section 6: Microsoft's new **ARM / Azure FinOps MCP Server (public preview)** and the community alternatives.
 
 **What the Azure MCP server DOES provide:**
 - Resource monitoring (logs, metrics, activity logs)
@@ -122,7 +122,7 @@ List my Azure subscriptions and resource groups, then show me the storage accoun
 - "Get recent activity logs for my resources"
 - "Show metrics for my AKS clusters"
 
-**Note:** For cost and billing queries, the official Azure MCP server doesn't currently support these. See section 6 for community alternatives that provide FinOps capabilities.
+**Note:** You can now ask the official Azure MCP server for **retail pricing** (e.g., "What is the pricing for SKU Standard_D4s_v5 in eastus, including savings plan rates?"). For **actual cost and billing data**, it doesn't support these queries — see section 6 for the official ARM / FinOps MCP Server preview and community alternatives.
 
 
 
@@ -130,24 +130,32 @@ List my Azure subscriptions and resource groups, then show me the storage accoun
 
 ## 6. Comparison with other Azure MCP servers
 
-There are community-created Azure MCP servers that **DO provide FinOps/cost management features**, but they are **not official** and require **local installation**:
+Since mid-2026 there is an **official Microsoft option for FinOps** in public preview, alongside the community servers:
 
 | MCP Server | Official? | Type | Cost/Billing APIs? | Production Ready? | Installation |
 |------------|-----------|------|-------------------|-------------------|--------------|
-| **@azure/mcp** (this tutorial) | ✅ Yes (Microsoft) | Remote | ❌ No | ✅ Yes | `npx @azure/mcp@latest` |
-| **[julianobarbosa/azure-finops-mcp-server](https://github.com/julianobarbosa/azure-finops-mcp-server)** ⭐ **Recommended for FinOps** | ❌ No (Community) | Local | ✅ Yes | ✅ Yes | Python package (`uv pip install azure-finops-mcp-server`) |
+| **[ARM MCP Server](https://github.com/Azure/Azure-Resource-Manager-MCP)** (aka **Azure FinOps MCP Server**) 🆕 | ✅ Yes (Microsoft) | Remote | 🟡 Rolling out (preview) | 🟡 Public preview | Open [aka.ms/JoinARMMCP](https://aka.ms/JoinARMMCP) in VS Code |
+| **@azure/mcp** (this tutorial) | ✅ Yes (Microsoft) | Remote | ⚠️ Retail pricing only | ✅ Yes | `npx @azure/mcp@latest` |
+| **[julianobarbosa/azure-finops-mcp-server](https://github.com/julianobarbosa/azure-finops-mcp-server)** ⭐ **Recommended for billing data today** | ❌ No (Community) | Local | ✅ Yes (Cost Management) | ✅ Yes | Python package (`uv pip install azure-finops-mcp-server`) |
 | **[mc5eamus/finopshub-mcp](https://github.com/mc5eamus/finopshub-mcp)** | ❌ No (Community) | Local | ✅ Yes | ❌ No (Proof-of-concept) | Clone repo + manual setup (Python, Docker) |
 
 **When to use each:**
 
+- **Use the ARM MCP Server / Azure FinOps MCP Server (official, public preview)** for:
+  - Natural-language **Azure Resource Graph** queries across your estate ("show all disks not attached to a VM", "find untagged resources created in the last 30 days")
+  - Inventory-driven waste detection and tag compliance audits
+  - Cost and usage intelligence in agent workflows (announced June 2026, rolling out under the FinOps branding)
+  - Caveats: requires **VS Code + GitHub Copilot** for now (Claude support announced as next); ships **deployment (write) tools** — disable them or scope your identity to Reader for FinOps-only use
+
 - **Use @azure/mcp (official)** for:
   - Resource management and monitoring
+  - **Retail pricing lookups and pre-deployment cost estimation** (SKU/region prices, reservation and savings plan rates)
   - Official Microsoft support
   - Easy remote installation
   - Long-term maintenance guarantee
 
-- **Use julianobarbosa/azure-finops-mcp-server (⭐ recommended community option)** for:
-  - **Cost analysis and billing data**
+- **Use julianobarbosa/azure-finops-mcp-server (⭐ community option, most direct path to your actual bill)** for:
+  - **Cost analysis and billing data** (Cost Management APIs)
   - FinOps workflow automation
   - Budget monitoring and cost optimization
   - **Production-grade quality**: 97.7% test coverage, 100% architecture compliance, GitHub Actions CI/CD
@@ -160,13 +168,15 @@ There are community-created Azure MCP servers that **DO provide FinOps/cost mana
   - No test coverage or CI/CD pipeline
   - Experimental features marked as WIP
   - Not recommended for production use
+  - For FinOps hubs, prefer Microsoft's official path: [Configure AI agents for FinOps hubs](https://learn.microsoft.com/en-us/cloud-computing/finops/toolkit/hubs/configure-ai)
 
 ---
 
 ## 7. Next steps
 
-- Review role requirements: [Azure MCP IAM guidance](../governance/security-privileges-azure.md)
+- Review security best practices: [Governance guides](../governance/INDEX.md)
 - Explore Azure resource queries and monitoring capabilities
-- **For FinOps/cost analysis**: Set up [julianobarbosa/azure-finops-mcp-server](https://github.com/julianobarbosa/azure-finops-mcp-server) (recommended in section 6)
+- **Try the official preview**: Install the [ARM / Azure FinOps MCP Server](https://aka.ms/JoinARMMCP) for natural-language Resource Graph queries (requires VS Code + GitHub Copilot)
+- **For actual billing data today**: Set up [julianobarbosa/azure-finops-mcp-server](https://github.com/julianobarbosa/azure-finops-mcp-server) (see section 6)
 
 


### PR DESCRIPTION
## Why

Microsoft announced the **Azure FinOps MCP Server (public preview)** on June 23, 2026 ([From insight to action](https://azure.microsoft.com/en-us/blog/from-insight-to-action-the-next-phase-of-agentic-cloud-operations/)) — the FinOps-facing packaging of the **ARM MCP Server** (public preview since May 7, 2026). Our Azure docs still claimed "the official Azure MCP server does NOT expose cost management or billing APIs", which is now stale twice over: the ARM/FinOps MCP Server preview exists, and `@azure/mcp` gained a [retail pricing tool](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-pricing).

## What changed

- **servers/azure.md** — rewritten: "What changed in mid-2026" callout, ARM MCP Server row added to the comparison table (official, remote, preview), `@azure/mcp` cost column corrected to "Retail pricing only", governance note that the ARM MCP Server is NOT read-only (ships 3 deployment tools; recommend Reader + ARG scoping for FinOps use), install steps via aka.ms/JoinARMMCP, permissions section updated.
- **tutorials/04-azure-mcp-quickstart.md** — limitation warning replaced with the accurate nuance (retail pricing ≠ billing data), section 6 table and when-to-use guidance updated, next steps refreshed.
- **servers/configs/registry.yaml** — new `arm-mcp-server` entry (maturity: preview, 6 tools), `azure-mcp` entry description/security notes corrected. YAML validated (18 entries).
- **servers/INDEX.md, README.md, llms.txt** — counts and Azure summary lines updated; README "Recent Updates" bumped to July 2026 with the Azure item.
- **CHANGELOG.md** — [July 2026] entry.
- **Fixed broken link** — `governance/security-privileges-azure.md` never existed; both referencing files now point to the governance INDEX.
- **finopshub-mcp** guidance now points to Microsoft's official [Configure AI agents for FinOps hubs](https://learn.microsoft.com/en-us/cloud-computing/finops/toolkit/hubs/configure-ai) path.

## Positioning decision

Kept **julianobarbosa/azure-finops-mcp-server** as the recommended path to *actual billing data today* (the official preview currently requires VS Code + GitHub Copilot, and its cost/usage tooling is still rolling out), while making the official ARM/FinOps MCP Server the headline for estate-wide inventory/waste queries.

Note: pre-existing off-by-one between the registry (17 entries) and the docs ("18 documented") carried forward — docs now say 19 documented / 18 registry entries; llms.txt no longer claims a registry count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)