### PR TITLE
Add Costory FinOps MCP to the multi-cloud registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 A practical resource hub for FinOps practitioners, cloud engineers, and platform teams who want to use **AI agents** to automate cloud cost optimization. This repo provides tutorials, MCP server documentation, client guides, and security frameworks for implementing the Model Context Protocol across AWS, Azure, and GCP.
 
-**19 MCP servers documented** | **7 step-by-step tutorials** | **9 MCP clients compared** | **3 cloud providers covered**
+**20 MCP servers documented** | **7 step-by-step tutorials** | **9 MCP clients compared** | **3 cloud providers covered**
 
 ---
 
@@ -42,7 +42,7 @@ A practical resource hub for FinOps practitioners, cloud engineers, and platform
 | Section | What you'll find |
 |---------|-----------------|
 | [/foundations](./foundations) | What is MCP, how it works, architecture deep-dive |
-| [/servers](./servers) | 19 MCP servers — AWS, Azure, GCP, Tagging, JIRA, Slack |
+| [/servers](./servers) | 20 MCP servers — AWS, Azure, GCP, Tagging, JIRA, Slack |
 | [/clients](./clients) | 9 MCP clients compared — Claude, ChatGPT, Gemini, Copilot, Cursor, Kiro |
 | [/tutorials](./tutorials) | 7 step-by-step guides for AWS, Azure, GCP cost analysis |
 | [/governance](./governance) | Security best practices, IAM policies, vulnerability guides |

--- a/servers/INDEX.md
+++ b/servers/INDEX.md
@@ -2,7 +2,7 @@
 
 **Last Updated**: July 2026
 
-A curated registry of 20 MCP servers for cloud cost optimization, FinOps automation, and AI-powered cost management across AWS, Azure, and GCP. Includes cloud provider billing servers, tagging governance tools, and workflow integrations (JIRA, Slack).
+A curated registry of 21 MCP servers for cloud cost optimization, FinOps automation, and AI-powered cost management across AWS, Azure, and GCP. Includes cloud provider billing servers, tagging governance tools, and workflow integrations (JIRA, Slack).
 
 See [`configs/registry.yaml`](./configs/registry.yaml) for the machine-readable registry.
 
@@ -20,6 +20,7 @@ See [`configs/registry.yaml`](./configs/registry.yaml) for the machine-readable 
 - **[GCP MCP Servers](./gcp.md)** — BigQuery billing exports, Compute Engine, GKE, community servers
 
 ### Multi-cloud Cost Servers
+- **[Costory FinOps MCP](https://docs.costory.io/features/mcp)** — Hosted server over an allocation and correlation layer for AWS, GCP, Azure plus SaaS and LLM spend: allocated cost queries, cost-change diffs against deploy events, unit economics, alerts and reports from chat
 - **[nable (finops-mcp)](https://github.com/chaandannn/finopsmcp)** — Local-first server for AWS, Azure and GCP plus AI and SaaS spend: cost queries, anomaly detection, rightsizing, LLM token tracking
 
 ### Workflow & Collaboration

--- a/servers/configs/registry.yaml
+++ b/servers/configs/registry.yaml
@@ -302,6 +302,34 @@
 
 # ── Multi-cloud ──────────────────────────────────────────
 
+- name: costory-finops-mcp
+  provider: Multi-cloud
+  repo: https://github.com/costory-io/costory-finops-mcp-skills
+  homepage: https://docs.costory.io/features/mcp
+  category: reporting
+  description: "Hosted context layer over cloud and AI billing: allocated, correlated spend across AWS, GCP, Azure plus SaaS and LLM providers, with alerts, reports and dashboards created from chat."
+  capabilities:
+    - query-cost-and-usage
+    - run-cost-change-diff-tree
+    - correlate-cost-with-deploy-events
+    - query-unit-economics
+    - create-alert
+    - create-report
+    - create-dashboard
+  auth:
+    - "OAuth 2.1 with dynamic client registration (no cloud credentials given to the MCP client)"
+  maturity: ga
+  security_notes: "Commercial SaaS. Remote server, so billing data is ingested into the vendor workspace rather than queried live from the user's cloud accounts; scoping follows the caller's workspace role. Write tools (alerts, reports, dashboards, events) act only inside the Costory workspace."
+  tags:
+    - finops
+    - multi-cloud
+    - aws
+    - azure
+    - gcp
+    - ai-costs
+    - allocation
+    - hosted
+
 - name: nable-finops-mcp
   provider: Multi-cloud
   repo: https://github.com/chaandannn/finopsmcp


### PR DESCRIPTION
## What this adds

A `costory-finops-mcp` entry in `servers/configs/registry.yaml`, a matching bullet under **Multi-cloud Cost Servers** in `servers/INDEX.md`, and a +1 bump to the server counts.

**Disclosure up front: I work at Costory.** I have tried to write the entry the way I would want a competitor's entry written, and I am happy to change the wording or drop it if it does not clear your inclusion bar.

## Why it belongs in Multi-cloud

The section currently has one entry (nable), which is local-first. Costory is the hosted counterpart: a remote MCP server over streamable HTTP with OAuth, sitting on an allocation and correlation layer rather than querying provider cost APIs live. The two are genuinely different architectures for the same job, so having both makes the section more useful to someone choosing.

The `security_notes` field states the hosted trade-off explicitly (billing data is ingested into the vendor workspace, it does not stay on the user's machine) so a reader comparing the two entries sees the real difference rather than marketing.

## Notes on specific fields

- `repo` points at the open skills and plugin packaging. The hosted server itself is closed source, so there is no server repo to link. `homepage` points at the MCP feature docs, which is the practical entry point.
- `capabilities` are the actual tool surfaces (cost and usage queries, cost-change diff tree, event correlation, unit economics, and the alert / report / dashboard write tools), not aspirational ones.
- `maturity: ga` because it is a live commercial product, not a preview.
- Key set and ordering follow the existing `nable-finops-mcp` entry; the list stays alphabetical by `name`.

## Counts

I bumped `README.md` from 19 to 20 and `INDEX.md` from 20 to 21. Heads up that those two numbers already disagreed with each other before this change (`grep -c '^- name:'` on `registry.yaml` was 19, and the July changelog line says 18), so I incremented rather than recounting. Happy to drop the count changes from this PR if you would rather recount them separately.

## Validation

- `registry.yaml` parses with `yaml.safe_load`, 20 entries.
- Key set is identical to the neighbouring entry.
- Links checked: repo, homepage.
