### PR TITLE
chore: pin an explicit ignore rule for Claude Code local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ yarn-error.log*
 # Local Claude Code prompts (kept locally for replay, not committed)
 .claude/prompts/
 
+# Local Claude Code settings (may hold tokens; only covered by *.json above)
+.claude/settings.local.json
+


### PR DESCRIPTION
Adds an explicit .claude/settings.local.json entry. The file was only covered incidentally by the generic *.json rule.