### PR TITLE
docs: align INDEX server count with registry (20)

### DIFF
--- a/servers/INDEX.md
+++ b/servers/INDEX.md
@@ -2,7 +2,7 @@
 
 **Last Updated**: July 2026
 
-A curated registry of 21 MCP servers for cloud cost optimization, FinOps automation, and AI-powered cost management across AWS, Azure, and GCP. Includes cloud provider billing servers, tagging governance tools, and workflow integrations (JIRA, Slack).
+A curated registry of 20 MCP servers for cloud cost optimization, FinOps automation, and AI-powered cost management across AWS, Azure, and GCP. Includes cloud provider billing servers, tagging governance tools, and workflow integrations (JIRA, Slack).
 
 See [`configs/registry.yaml`](./configs/registry.yaml) for the machine-readable registry.
 


### PR DESCRIPTION
INDEX.md said 21 servers while registry.yaml has 20 entries and README says 20. The off-by-one predates #15; this brings INDEX in line.