### PR TITLE
Add OptimNow AI cost and FinOps knowledge MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [September 2026] - 2026-09-02
+
+### Added
+- **AI Cost & FinOps Knowledge section** in `servers/INDEX.md` and `servers/configs/registry.yaml` with three OptimNow servers: `cloud-finops-mcp` (FinOps knowledge references and waste-detection playbooks, hosted or `pip install cloud-finops-mcp`), `ai-pricing-hub-mcp` (OptimToken: live dated LLM and compute prices across seven clouds), and `ai-roi-calculator-mcp` (ROI, payback, break-even and sensitivity analysis for an LLM use case). All hosted, read-only, no credentials.
+- **`costory-finops-mcp` registry entry** under Multi-cloud (hosted allocation and correlation layer for AWS, GCP, Azure plus SaaS and LLM spend), contributed by Costory in [#15](https://github.com/OptimNow/finops-mcp-resources/pull/15).
+
+### Changed
+- **Server count** now 23 in `README.md` and `servers/INDEX.md`, matching `registry.yaml`. `INDEX.md` had been one ahead of the registry since July; reconciled in [#18](https://github.com/OptimNow/finops-mcp-resources/pull/18).
+- **`servers/configs/schema.json`** provider enum gains `Multi-cloud`, which the registry had been using since the nable entry.
+
+---
+
 ## [July 2026] - 2026-07-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 A practical resource hub for FinOps practitioners, cloud engineers, and platform teams who want to use **AI agents** to automate cloud cost optimization. This repo provides tutorials, MCP server documentation, client guides, and security frameworks for implementing the Model Context Protocol across AWS, Azure, and GCP.
 
-**20 MCP servers documented** | **7 step-by-step tutorials** | **9 MCP clients compared** | **3 cloud providers covered**
+**23 MCP servers documented** | **7 step-by-step tutorials** | **9 MCP clients compared** | **3 cloud providers covered**
 
 ---
 
@@ -42,7 +42,7 @@ A practical resource hub for FinOps practitioners, cloud engineers, and platform
 | Section | What you'll find |
 |---------|-----------------|
 | [/foundations](./foundations) | What is MCP, how it works, architecture deep-dive |
-| [/servers](./servers) | 20 MCP servers — AWS, Azure, GCP, Tagging, JIRA, Slack |
+| [/servers](./servers) | 23 MCP servers — AWS, Azure, GCP, Multi-cloud, AI pricing & ROI, Tagging, JIRA, Slack |
 | [/clients](./clients) | 9 MCP clients compared — Claude, ChatGPT, Gemini, Copilot, Cursor, Kiro |
 | [/tutorials](./tutorials) | 7 step-by-step guides for AWS, Azure, GCP cost analysis |
 | [/governance](./governance) | Security best practices, IAM policies, vulnerability guides |

--- a/servers/INDEX.md
+++ b/servers/INDEX.md
@@ -1,8 +1,8 @@
 # MCP Servers for Cloud FinOps and Cost Optimization
 
-**Last Updated**: July 2026
+**Last Updated**: September 2026
 
-A curated registry of 20 MCP servers for cloud cost optimization, FinOps automation, and AI-powered cost management across AWS, Azure, and GCP. Includes cloud provider billing servers, tagging governance tools, and workflow integrations (JIRA, Slack).
+A curated registry of 23 MCP servers for cloud cost optimization, FinOps automation, and AI-powered cost management across AWS, Azure, and GCP. Includes cloud provider billing servers, tagging governance tools, and workflow integrations (JIRA, Slack).
 
 See [`configs/registry.yaml`](./configs/registry.yaml) for the machine-readable registry.
 
@@ -22,6 +22,12 @@ See [`configs/registry.yaml`](./configs/registry.yaml) for the machine-readable 
 ### Multi-cloud Cost Servers
 - **[Costory FinOps MCP](https://docs.costory.io/features/mcp)** — Hosted server over an allocation and correlation layer for AWS, GCP, Azure plus SaaS and LLM spend: allocated cost queries, cost-change diffs against deploy events, unit economics, alerts and reports from chat
 - **[nable (finops-mcp)](https://github.com/chaandannn/finopsmcp)** — Local-first server for AWS, Azure and GCP plus AI and SaaS spend: cost queries, anomaly detection, rightsizing, LLM token tracking
+
+### AI Cost & FinOps Knowledge Servers
+Built by OptimNow, the maintainers of this repository. All three are hosted, read-only and take no credentials.
+- **[Cloud FinOps MCP](https://github.com/OptimNow/cloud-finops-skills)** — FinOps knowledge for AI agents: curated references on AWS, Azure, GCP and OCI billing mechanics, commitments, allocation, AI inference economics and data platforms, plus named-pattern waste-detection playbooks with tested queries. Hosted endpoint or `pip install cloud-finops-mcp`
+- **[OptimToken MCP (AI Pricing Hub)](https://github.com/OptimNow/ai-pricing-hub-mcp)** — Live, dated LLM prices for 250+ models and compute instance rates across seven clouds: model comparison and recommendation, cost per request and per month from your token shape, cache hit rate and batch eligibility
+- **[AI ROI Calculator MCP](https://github.com/OptimNow/ai-roi-calculator-mcp)** — Business case for an LLM use case: ROI, payback, break-even volume and sensitivity analysis from live prices and a 3-layer cost model (inference, harness, business value)
 
 ### Workflow & Collaboration
 - **[FinOps Tagging Compliance](./tagging.md)** — Tag compliance checking, drift detection, cost attribution gap analysis

--- a/servers/configs/registry.yaml
+++ b/servers/configs/registry.yaml
@@ -355,6 +355,86 @@
     - gcp
     - ai-costs
 
+# ── AI Cost & FinOps Knowledge ───────────────────────────
+
+- name: ai-pricing-hub-mcp
+  provider: Multi-cloud
+  repo: https://github.com/OptimNow/ai-pricing-hub-mcp
+  homepage: https://optimtoken.optimnow.io
+  category: pricing
+  description: "OptimToken MCP: live, dated LLM prices for 250+ models and compute instance rates across AWS, Azure, GCP, OCI, OVH, DigitalOcean and Alibaba. Cost per request and per month from your token shape, cache hit rate and batch eligibility."
+  capabilities:
+    - compare-llm-models
+    - recommend-llm-model
+    - compare-models-side-by-side
+    - estimate-llm-cost
+    - compare-compute-pricing
+  auth:
+    - "None (hosted streamable-HTTP endpoint, no credentials)"
+  maturity: beta
+  security_notes: "Read-only; takes no cloud or API credentials; nothing sent is stored. Hosted on Alpic. Prices come from the OptimToken catalogue with tiered fallback, and every answer carries a provenance flag saying whether prices were verified."
+  tags:
+    - finops
+    - ai-costs
+    - llm-pricing
+    - pricing
+    - multi-cloud
+    - hosted
+    - optimnow
+
+- name: ai-roi-calculator-mcp
+  provider: Other
+  repo: https://github.com/OptimNow/ai-roi-calculator-mcp
+  homepage: https://airoicalculator.optimnow.io
+  category: other
+  description: "AI business-case calculator: ROI, payback and break-even volume for an LLM use case, from live model prices, a 3-layer cost model (inference, harness, business value) and a sensitivity analysis. Every figure carries its price date."
+  capabilities:
+    - calculate-roi
+    - lookup-model-price
+    - load-preset
+    - sensitivity-analysis
+  auth:
+    - "None (hosted streamable-HTTP endpoint, no credentials)"
+  maturity: beta
+  security_notes: "Read-only; takes no credentials; nothing sent is stored. Hosted on Alpic. Formulas are synced verbatim from the open-source web calculator and pinned by golden tests, so the server and the web app return the same number."
+  tags:
+    - finops
+    - ai-costs
+    - roi
+    - llm-pricing
+    - hosted
+    - optimnow
+
+- name: cloud-finops-mcp
+  provider: Multi-cloud
+  repo: https://github.com/OptimNow/cloud-finops-skills
+  homepage: https://pypi.org/project/cloud-finops-mcp/
+  category: other
+  description: "FinOps knowledge server: curated references (AWS, Azure, GCP, OCI billing mechanics, commitments, allocation, chargeback, AI inference economics, Kubernetes, Databricks, Fabric, Snowflake, SaaS, GreenOps) and named-pattern waste-detection playbooks with tested detection queries. Same library ships as an agent skill."
+  capabilities:
+    - list-references
+    - find-references
+    - get-reference
+    - list-playbooks
+    - find-playbooks
+    - get-playbook
+  auth:
+    - "None (hosted streamable-HTTP endpoint, or local pip package; no credentials either way)"
+  maturity: ga
+  security_notes: "Read-only knowledge retrieval; cannot see or touch the user's cloud accounts. Hosted endpoint on Alpic, or run locally from PyPI so nothing leaves the machine. Content licensed CC BY-SA 4.0."
+  tags:
+    - finops
+    - multi-cloud
+    - aws
+    - azure
+    - gcp
+    - oci
+    - ai-costs
+    - knowledge
+    - playbooks
+    - hosted
+    - optimnow
+
 # ── Workflow & Collaboration ─────────────────────────────
 
 - name: finops-tagging-mcp

--- a/servers/configs/schema.json
+++ b/servers/configs/schema.json
@@ -25,7 +25,7 @@
       },
       "provider": {
         "type": "string",
-        "enum": ["AWS", "Azure", "GCP", "Other"]
+        "enum": ["AWS", "Azure", "GCP", "Multi-cloud", "Other"]
       },
       "repo": {
         "type": "string",


### PR DESCRIPTION
## What this adds

Three OptimNow servers in a new **AI Cost & FinOps Knowledge** section of `servers/configs/registry.yaml` and `servers/INDEX.md`:

| Entry | What it is | Maturity |
|---|---|---|
| `cloud-finops-mcp` | FinOps knowledge references and waste-detection playbooks. Hosted endpoint or `pip install cloud-finops-mcp`. Same library ships as an agent skill. | ga |
| `ai-pricing-hub-mcp` | OptimToken: live, dated LLM prices for 250+ models and compute instance rates across seven clouds. | beta |
| `ai-roi-calculator-mcp` | ROI, payback, break-even volume and sensitivity analysis for an LLM use case, from live prices and a 3-layer cost model. | beta |

All three are hosted on Alpic, read-only, and take no credentials. The INDEX section says up front that they are built by the maintainers of this repository.

## Also in this PR

- Server count 20 -> 23 in `README.md` (both lines) and `servers/INDEX.md`; INDEX "Last Updated" moved to September 2026.
- `servers/configs/schema.json` provider enum gains `Multi-cloud`, which nable and Costory already use.
- `CHANGELOG.md` gets a September 2026 entry, which also records the Costory entry merged in #15 and the count fix in #18.

## Validation

- `registry.yaml` parses, 23 entries, names unique, alphabetical within the new section.
- The three new entries validate against `schema.json`.
- Links checked: both GitHub repos, PyPI page, both web apps, and the three hosted endpoints respond.

## Pre-existing schema violations, not touched here

`schema.json` is not enforced anywhere, and a few older entries would fail it: `arm-mcp-server` uses `maturity: preview` (not in the enum), and the `finops-tagging-mcp` repo link returns 404. Worth a separate cleanup.